### PR TITLE
Admin create fetching

### DIFF
--- a/src/api/KintaiAuth.ts
+++ b/src/api/KintaiAuth.ts
@@ -2,7 +2,9 @@ import { AuthApi } from "@/api/typescript-axios";
 import { Configuration } from "@/api/typescript-axios/configuration";
 import axios from "axios";
 
-const axiosInstance = axios.create();
+const axiosInstance = axios.create({
+  withCredentials: true,
+});
 
 const KintaiAuth = new AuthApi(
   {

--- a/src/api/KintaiEmployee.ts
+++ b/src/api/KintaiEmployee.ts
@@ -2,7 +2,9 @@ import { EmployeeApi } from "@/api/typescript-axios";
 import { Configuration } from "@/api/typescript-axios/configuration";
 import axios from "axios";
 
-const axiosInstance = axios.create();
+const axiosInstance = axios.create({
+  withCredentials: true,
+});
 
 const KintaiEmployee = new EmployeeApi(
   {

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -2,6 +2,7 @@ import KintaiAuth from "@/api/KintaiAuth";
 import RadioButton from "./RadioButton";
 import { useForm } from "react-hook-form";
 import Cookies from "js-cookie";
+import Router from "next/router";
 
 type FormArray = {
   action: string;
@@ -30,6 +31,7 @@ export default function From({ action, submitLabel, rows }: FormArray) {
       Cookies.set("access-token", res.headers["access-token"]);
       Cookies.set("client", res.headers["client"]);
       Cookies.set("uid", res.headers["uid"]);
+      Router.push("/");
     } catch (error) {
       console.log(error);
     }

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -19,6 +19,8 @@ type FormProps = {
 type DataProps = {
   email?: string;
   password?: string;
+  name?: string;
+  passwordConfirmation?: string;
 };
 
 export default function Form({

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -29,7 +29,11 @@ export default function Form({
   rows,
   setData,
 }: FormArray) {
-  const { handleSubmit, register } = useForm();
+  const {
+    handleSubmit,
+    register,
+    formState: { isValid },
+  } = useForm();
 
   const onSubmit = (data: DataProps) => {
     // typeエラーが出てしまうので、setData && としている。全てのページを修正できたら不必要になるはず
@@ -48,7 +52,10 @@ export default function Form({
               <input
                 type={row.type}
                 className="form-control"
-                {...register(`${row.registerLabel}`)}
+                {...register(`${row.registerLabel}`, {
+                  required: "必須入力です",
+                  minLength: row.type === "password" ? 6 : 1,
+                })}
               />
               <div className="form-text">{row.warningLabel}</div>
             </>
@@ -56,7 +63,12 @@ export default function Form({
         </div>
       ))}
       <div>
-        <button type="submit" className="btn btn-primary mt-4">
+        <button
+          type="submit"
+          className={
+            isValid ? "btn btn-primary mt-4" : "btn btn-primary mt-4 disabled"
+          }
+        >
           {submitLabel}
         </button>
       </div>

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -1,13 +1,12 @@
-import KintaiAuth from "@/api/KintaiAuth";
+import { Dispatch, SetStateAction } from "react";
 import RadioButton from "./RadioButton";
 import { useForm } from "react-hook-form";
-import Cookies from "js-cookie";
-import Router from "next/router";
 
 type FormArray = {
   action: string;
   submitLabel: string;
   rows: FormProps[];
+  setData?: Dispatch<SetStateAction<object>>;
 };
 
 type FormProps = {
@@ -22,19 +21,17 @@ type DataProps = {
   password?: string;
 };
 
-export default function From({ action, submitLabel, rows }: FormArray) {
+export default function Form({
+  action,
+  submitLabel,
+  rows,
+  setData,
+}: FormArray) {
   const { handleSubmit, register } = useForm();
 
-  const onSubmit = async (data: DataProps) => {
-    try {
-      const res = await KintaiAuth.signInAdmin(data);
-      Cookies.set("access-token", res.headers["access-token"]);
-      Cookies.set("client", res.headers["client"]);
-      Cookies.set("uid", res.headers["uid"]);
-      Router.push("/");
-    } catch (error) {
-      console.log(error);
-    }
+  const onSubmit = (data: DataProps) => {
+    // typeエラーが出てしまうので、setData && としている。全てのページを修正できたら不必要になるはず
+    setData && setData(data);
   };
 
   return (

--- a/src/pages/admin/admins/edit/index.tsx
+++ b/src/pages/admin/admins/edit/index.tsx
@@ -1,6 +1,6 @@
 import AdminHeader from "@/components/AdminHeader";
 import MyHead from "@/components/MyHead";
-import Form from "@/components/From";
+import Form from "@/components/Form";
 
 const rows = [
   {

--- a/src/pages/admin/admins/new/index.tsx
+++ b/src/pages/admin/admins/new/index.tsx
@@ -1,6 +1,6 @@
 import AdminHeader from "@/components/AdminHeader";
 import MyHead from "@/components/MyHead";
-import Form from "@/components/From";
+import Form from "@/components/Form";
 
 const rows = [
   {

--- a/src/pages/admin/admins/new/index.tsx
+++ b/src/pages/admin/admins/new/index.tsx
@@ -1,36 +1,71 @@
 import AdminHeader from "@/components/AdminHeader";
 import MyHead from "@/components/MyHead";
 import Form from "@/components/Form";
+import { useEffect, useState } from "react";
+import KintaiAuth from "@/api/KintaiAuth";
+import Router from "next/router";
 
 const rows = [
   {
     nameLabel: "管理者名",
     type: "text",
+    registerLabel: "name",
   },
   {
     nameLabel: "メールアドレス",
     type: "email",
+    registerLabel: "email",
   },
   {
     nameLabel: "パスワード",
     type: "password",
     warningLabel: "6文字以上",
+    registerLabel: "password",
   },
   {
     nameLabel: "パスワード(確認)",
     type: "password",
     warningLabel: "6文字以上",
+    registerLabel: "password_confirmation",
   },
 ];
 
+type DataProps = {
+  name?: string;
+  email?: string;
+  password?: string;
+  password_confirmation?: string;
+};
+
 export default function AdminAdminNew() {
+  const [data, setData] = useState<DataProps>({});
+
+  useEffect(() => {
+    (async () => {
+      if (
+        data.name &&
+        data.email &&
+        data.password &&
+        data.password_confirmation
+      ) {
+        await KintaiAuth.createAdmin(data);
+        Router.push("/");
+      }
+    })();
+  }, [data]);
+
   return (
     <>
       <MyHead title="管理者登録" />
       <AdminHeader />
       <main className="text-center">
-        <h2 className="mt-5 mb-3">管理登録</h2>
-        <Form action="/" submitLabel="管理者を登録する" rows={rows} />
+        <h2 className="mt-5 mb-3">管理者登録</h2>
+        <Form
+          action="/"
+          submitLabel="管理者を登録する"
+          rows={rows}
+          setData={setData}
+        />
       </main>
     </>
   );

--- a/src/pages/admin/admins/new/index.tsx
+++ b/src/pages/admin/admins/new/index.tsx
@@ -26,7 +26,7 @@ const rows = [
     nameLabel: "パスワード(確認)",
     type: "password",
     warningLabel: "6文字以上",
-    registerLabel: "password_confirmation",
+    registerLabel: "passwordConfirmation",
   },
 ];
 
@@ -34,7 +34,7 @@ type DataProps = {
   name?: string;
   email?: string;
   password?: string;
-  password_confirmation?: string;
+  passwordConfirmation?: string;
 };
 
 export default function AdminAdminNew() {
@@ -46,7 +46,7 @@ export default function AdminAdminNew() {
         data.name &&
         data.email &&
         data.password &&
-        data.password_confirmation
+        data.passwordConfirmation
       ) {
         await KintaiAuth.createAdmin(data);
         Router.push("/");

--- a/src/pages/admin/employees/new/index.tsx
+++ b/src/pages/admin/employees/new/index.tsx
@@ -1,6 +1,6 @@
 import AdminHeader from "@/components/AdminHeader";
 import MyHead from "@/components/MyHead";
-import Form from "@/components/From";
+import Form from "@/components/Form";
 
 const rows = [
   {

--- a/src/pages/admin/sessions/index.tsx
+++ b/src/pages/admin/sessions/index.tsx
@@ -2,6 +2,10 @@ import Header from "@/components/Header";
 import MyHead from "@/components/MyHead";
 import Link from "next/link";
 import Form from "@/components/Form";
+import Cookies from "js-cookie";
+import Router from "next/router";
+import KintaiAuth from "@/api/KintaiAuth";
+import { useEffect, useState } from "react";
 
 const rows = [
   {
@@ -16,14 +20,38 @@ const rows = [
   },
 ];
 
+type DataProps = {
+  email?: string;
+  password?: string;
+};
+
 export default function AdminSessions() {
+  const [data, setData] = useState<DataProps>({});
+
+  useEffect(() => {
+    (async () => {
+      if (data.email && data.password) {
+        const res = await KintaiAuth.signInAdmin(data);
+        Cookies.set("access-token", res.headers["access-token"]);
+        Cookies.set("client", res.headers["client"]);
+        Cookies.set("uid", res.headers["uid"]);
+        Router.push("/");
+      }
+    })();
+  }, [data]);
+
   return (
     <>
       <MyHead title="管理者ログイン" />
       <Header />
       <main className="text-center">
         <h2 className="mt-5 mb-3">管理者ログイン</h2>
-        <Form action="/" submitLabel="管理者としてログインする" rows={rows} />
+        <Form
+          action="/admin"
+          submitLabel="管理者としてログインする"
+          rows={rows}
+          setData={setData}
+        />
         <div className="mt-3">
           {/* TODO : 遷移先調整 */}
           <Link href="/">ゲスト管理者ログイン</Link>

--- a/src/pages/admin/sessions/index.tsx
+++ b/src/pages/admin/sessions/index.tsx
@@ -1,7 +1,7 @@
 import Header from "@/components/Header";
 import MyHead from "@/components/MyHead";
 import Link from "next/link";
-import Form from "@/components/From";
+import Form from "@/components/Form";
 
 const rows = [
   {

--- a/src/pages/employee/mypage/edit/index.tsx
+++ b/src/pages/employee/mypage/edit/index.tsx
@@ -1,6 +1,6 @@
 import EmployeeHeader from "@/components/EmployeeHeader";
 import MyHead from "@/components/MyHead";
-import Form from "@/components/From";
+import Form from "@/components/Form";
 
 const rows = [
   {

--- a/src/pages/employee/sessions/index.tsx
+++ b/src/pages/employee/sessions/index.tsx
@@ -1,7 +1,7 @@
 import Header from "@/components/Header";
 import MyHead from "@/components/MyHead";
 import Link from "next/link";
-import Form from "@/components/From";
+import Form from "@/components/Form";
 
 const rows = [
   {


### PR DESCRIPTION
[行ったこと]

- フォームコンポーネントの名称が From とタイポしていたので、Form に変更
- Form コンポーネントに直接ログイン機能をつけていたが、Form 自体は共通化したものなので、pages側にログインのapiを叩く箇所を移植
- admin/new ページで、form入力後、管理者の新規登録を行うためのapiを叩けるようにした 
- 入力値がないと、送信ボタンを押せないように調整した


<img width="914" alt="スクリーンショット 2023-12-26 10 35 34" src="https://github.com/tatata05/next-app/assets/123435331/ce4710c3-cd3d-469c-a6ef-a225ac474997">
<img width="923" alt="スクリーンショット 2023-12-26 10 35 48" src="https://github.com/tatata05/next-app/assets/123435331/dcb34232-21a5-43e2-9344-9d938b30147a">
<img width="1194" alt="スクリーンショット 2023-12-26 10 45 51" src="https://github.com/tatata05/next-app/assets/123435331/a5e4b437-7a83-4b61-9d21-71f791ca49b8">

